### PR TITLE
Issue #31: Problem with radio buttons if field is int

### DIFF
--- a/src/Database/MysqlDbConnection.php
+++ b/src/Database/MysqlDbConnection.php
@@ -511,8 +511,8 @@ class MysqlDbConnection extends DbConnection
                 case FieldType::INT:
                     #print "REDCAP TYPE FOR {$fieldDbName}: {$redcapType}\n";
                     if (empty($rowData[$fieldDbName])
-                            && $rowData[$fieldDbName] !== 0
-                            && $rowData[$fieldDbName] !== '0') {
+                            && $rowData[$fieldDbName] != 0
+                            && $rowData[$fieldDbName] != '0') {
                         if (strcasecmp($redcapType, 'checkbox') === 0) {
                             $rowValues[] = 0;
                         } else {

--- a/src/Database/PdoDbConnection.php
+++ b/src/Database/PdoDbConnection.php
@@ -402,8 +402,8 @@ abstract class PdoDbConnection extends DbConnection
                 case FieldType::INT:
                     #print "REDCAP TYPE FOR {$fieldDbName}: {$redcapType}\n";
                     if (empty($rowData[$fieldDbName])
-                        && $rowData[$fieldDbName] !== 0
-                        && $rowData[$fieldDbName] !== '0') {
+                        && $rowData[$fieldDbName] != 0
+                        && $rowData[$fieldDbName] != '0') {
                         if (strcasecmp($redcapType, 'checkbox') === 0) {
                             $rowValues[] = 0;
                         } else {


### PR DESCRIPTION
I changed the strict comparison as the if statement will fail since the value 0 and '0' will never both evaluate to true. This was resulting in null being inserted into the target database for checkbox and radio fields that were being inserted as integers.